### PR TITLE
Reuse existing buffers in floating windows

### DIFF
--- a/lua/todotxt/utils.lua
+++ b/lua/todotxt/utils.lua
@@ -189,6 +189,10 @@ utils.toggle_floating_file = function(file_path, file, title)
     buffer = state[file].buf,
     desc = "todo.txt: exit window with `q`",
   })
+
+  -- trigger ghost text draw immediately if enabled
+  local ok, gt = pcall(require, "todotxt.ghost_text")
+  if ok and gt then gt.update() end
 end
 
 --- Return infos about the current window


### PR DESCRIPTION
This swaps out the nvim_buf_set_name flow with “reuse if open, edit if not”. If todo.txt/done.txt is already open, the floating window attaches to that buffer, otherwise it edits the file in the scratch buffer.

Also fixed ghost text not appearing despite enable being set to true.

Closes #12 
Closes #14 