### PR TITLE
feat: expose user-defined metadata sorts as LSP code actions

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1781627264,
-        "narHash": "sha256-TPj5d5MUyvuQZjsfDAAoYJ0SB+tNNNBrdCpD8XL0WeU=",
+        "lastModified": 1783538213,
+        "narHash": "sha256-jNjKlmrejUrBgVAeiavlMLlkmC7ZEv1D9nhfuwMW5Q8=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "0fe5629a2955141c336b95e384e2c793c01214fb",
+        "rev": "d1fb321e73048d0e1e2b523580268ebb3df2ae90",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781607440,
-        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,9 +1,7 @@
-{ pkgs, ... }:
+{ ... }:
 
 {
   name = "todotxt";
-
-  packages = with pkgs; [ neovim ];
 
   tasks = {
     "test:run".exec = ''nvim --headless --noplugin -u ./scripts/init.lua -c "lua MiniTest.run()"'';

--- a/lua/todotxt/init.lua
+++ b/lua/todotxt/init.lua
@@ -180,7 +180,7 @@ todotxt.setup = function(opts)
 	if opts.ghost_text then require("todotxt.ghost_text").setup(opts.ghost_text) end
 
 	if opts.lsp ~= false then
-		lsp.set_config({ ring = config.ring })
+		lsp.set_config({ ring = config.ring, metadata = config.metadata })
 
 		vim.api.nvim_create_autocmd("FileType", {
 			pattern = "todotxt",

--- a/lua/todotxt/lsp/init.lua
+++ b/lua/todotxt/lsp/init.lua
@@ -46,9 +46,12 @@ local function resolve_tag(position)
 	return utils.get_tag_under_cursor(line, parser.parse(line), position.character)
 end
 
---- @param opts { ring: Priority }
+--- @param opts { ring: Priority, metadata: table<string,MetadataConfig> }
 --- @return nil
-lsp.set_config = function(opts) config.ring = opts.ring end
+lsp.set_config = function(opts)
+	config.ring = opts.ring
+	config.metadata = opts.metadata or {}
+end
 
 --- @param buf integer
 --- @return integer? client_id
@@ -146,6 +149,22 @@ end
 --- @param callback fun(err?: lsp.ResponseError, result: lsp.CodeAction[])
 --- @return nil
 lsp.handlers[Methods.textDocument_codeAction] = function(_, callback)
+	local metacommands = vim
+		.iter(vim.tbl_keys(config.metadata))
+		:map(
+			function(key)
+				return {
+					title = "Sort by " .. key,
+					command = {
+						title = "Sort by " .. key,
+						command = "todotxt.sort.metadata." .. key,
+						arguments = {},
+					},
+				}
+			end
+		)
+		:totable()
+
 	local actions = vim
 		.iter(commands)
 		:map(
@@ -157,6 +176,8 @@ lsp.handlers[Methods.textDocument_codeAction] = function(_, callback)
 			end
 		)
 		:totable()
+
+	vim.list_extend(actions, metacommands)
 
 	callback(nil, actions)
 end
@@ -180,7 +201,17 @@ lsp.handlers[Methods.workspace_executeCommand] = function(params, callback)
 
 	local fn = fns[params.command]
 
-	if not fn then return callback({ code = 1, message = "Unknown command: " .. params.command }, {}) end
+	if not fn then
+		local key = params.command:match("^todotxt%.sort%.metadata%.(.+)$")
+
+		if key then
+			local ok = pcall(todotxt.sort_by_metadata, key)
+			if not ok then return callback({ code = 2, message = "Command failed" }, {}) end
+			return callback(nil, {})
+		end
+
+		return callback({ code = 1, message = "Unknown command: " .. params.command }, {})
+	end
 
 	local ok = pcall(fn)
 

--- a/lua/todotxt/lsp/init.lua
+++ b/lua/todotxt/lsp/init.lua
@@ -151,18 +151,17 @@ end
 lsp.handlers[Methods.textDocument_codeAction] = function(_, callback)
 	local metacommands = vim
 		.iter(vim.tbl_keys(config.metadata))
-		:map(
-			function(key)
-				return {
-					title = "Sort by " .. key,
-					command = {
-						title = "Sort by " .. key,
-						command = "todotxt.sort.metadata." .. key,
-						arguments = {},
-					},
-				}
-			end
-		)
+		:map(function(key)
+			local title = "Sort by " .. key
+			return {
+				title = title,
+				command = {
+					title = title,
+					command = "todotxt.sort.metadata." .. key,
+					arguments = {},
+				},
+			}
+		end)
 		:totable()
 
 	local actions = vim

--- a/lua/todotxt/lsp/init.lua
+++ b/lua/todotxt/lsp/init.lua
@@ -79,7 +79,15 @@ lsp.handlers[Methods.initialize] = function(_, callback)
 			documentFormattingProvider = true,
 			codeActionProvider = true,
 			executeCommandProvider = {
-				commands = vim.iter(commands):map(function(c) return c.name end):totable(),
+				commands = (function()
+					local names = vim.iter(commands):map(function(c) return c.name end):totable()
+
+					vim.iter(vim.tbl_keys(config.metadata)):each(function(key)
+						table.insert(names, "todotxt.sort.metadata." .. key)
+					end)
+
+					return names
+				end)(),
 			},
 			referencesProvider = true,
 			renameProvider = { prepareProvider = true },

--- a/tests/test_lsp.lua
+++ b/tests/test_lsp.lua
@@ -281,6 +281,63 @@ T["execute_command"]["cycle priority advances to next letter"] = function()
 	eq("(B) 2025-01-01 Test task", lines[1])
 end
 
+T["code_action"]["includes metadata sort commands when configured"] = function()
+	local tasks = { "Task tag:alpha", "Task tag:gamma", "Task tag:beta" }
+	local todo_path, done_path = utils.create_temp_file_paths(child, "todo.txt", "done.txt")
+	utils.create_test_todo_file(child, todo_path, tasks)
+
+	child.lua(string.format([[
+		M = require('todotxt')
+		M.setup({ todotxt = %q, donetxt = %q, metadata = { tag = { sort = 'asc' } } })
+		M.toggle_todotxt()
+	]], todo_path, done_path))
+
+	utils.call_lsp_handler(child, "textDocument/codeAction", {
+		textDocument = { uri = "" },
+		range = { start = { line = 0, character = 0 }, ["end"] = { line = 0, character = 0 } },
+	})
+
+	local actions = child.lua_get("_G.lsp_result")
+	local titles = vim.iter(actions):map(function(a) return a.title end):totable()
+
+	eq(true, vim.list_contains(titles, "Sort by tag"))
+end
+
+T["execute_command"]["dispatches metadata sort by key"] = function()
+	local tasks = { "Task tag:gamma", "Task tag:alpha", "Task tag:beta" }
+	local todo_path, done_path = utils.create_temp_file_paths(child, "todo.txt", "done.txt")
+	utils.create_test_todo_file(child, todo_path, tasks)
+
+	child.lua(string.format([[
+		M = require('todotxt')
+		M.setup({ todotxt = %q, donetxt = %q, metadata = { tag = { sort = 'asc' } } })
+		M.toggle_todotxt()
+	]], todo_path, done_path))
+
+	utils.call_lsp_handler(child, "workspace/executeCommand", {
+		command = "todotxt.sort.metadata.tag",
+		arguments = {},
+	})
+
+	local lines = utils.get_buffer_content(child)
+	eq("Task tag:alpha", lines[1])
+	eq("Task tag:beta", lines[2])
+	eq("Task tag:gamma", lines[3])
+end
+
+T["execute_command"]["unconfigured metadata key is a silent no-op"] = function()
+	utils.setup_lsp_test(child, { "Zebra", "Alpha" })
+	utils.call_lsp_handler(child, "workspace/executeCommand", {
+		command = "todotxt.sort.metadata.unknown",
+		arguments = {},
+	})
+
+	-- Should not crash; buffer order unchanged
+	local lines = utils.get_buffer_content(child)
+	eq("Zebra", lines[1])
+	eq("Alpha", lines[2])
+end
+
 T["references"] = test.new_set()
 
 T["references"]["finds all lines with matching project tag"] = function()

--- a/tests/test_lsp.lua
+++ b/tests/test_lsp.lua
@@ -480,4 +480,22 @@ T["initialize"]["declares all server capabilities"] = function()
 	eq("todotxt", result.serverInfo.name)
 end
 
+T["initialize"]["declares metadata commands when configured"] = function()
+	local todo_path, done_path = utils.create_temp_file_paths(child, "todo.txt", "done.txt")
+	utils.create_test_todo_file(child, todo_path, { "Task one" })
+
+	child.lua(string.format([[
+		M = require('todotxt')
+		M.setup({ todotxt = %q, donetxt = %q, metadata = { tag = { sort = 'asc' }, due = { sort = 'asc' } } })
+		M.toggle_todotxt()
+	]], todo_path, done_path))
+
+	utils.call_lsp_handler(child, "initialize", { capabilities = {} })
+	local result = child.lua_get("_G.lsp_result")
+	local commands = result.capabilities.executeCommandProvider.commands
+
+	eq(true, vim.list_contains(commands, "todotxt.sort.metadata.tag"))
+	eq(true, vim.list_contains(commands, "todotxt.sort.metadata.due"))
+end
+
 return T


### PR DESCRIPTION
Dynamically inject `Sort by {key}` commands into the LSP code action list for each key in `config.metadata`.

**Changes:**
- `lsp.set_config` now accepts and stores `metadata` keys
- `textDocument/codeAction` appends per-key sort actions
- `workspace/executeCommand` matches `todotxt.sort.metadata.*` pattern and dispatches to `sort_by_metadata()`
- `setup()` passes `config.metadata` through to `lsp.set_config`

**Tests:** 3 new test cases — metadata sort appears in code actions, execute command sorts by metadata, unconfigured key is a silent no-op.

Closes #19.