### PR TITLE
fix: extend project and context parsing to support dots

### DIFF
--- a/lua/todotxt/lsp/init.lua
+++ b/lua/todotxt/lsp/init.lua
@@ -275,7 +275,7 @@ lsp.handlers[Methods.textDocument_rename] = function(params, callback)
 
 	local new_name = params.newName:gsub("^[+@]", "")
 
-	if not new_name:match("^%w+$") then
+	if not new_name:match("^[^%s]+$") then
 		return callback({ code = 1, message = "Invalid name: must be alphanumeric, no spaces or special characters" }, {})
 	end
 

--- a/lua/todotxt/lsp/init.lua
+++ b/lua/todotxt/lsp/init.lua
@@ -276,7 +276,7 @@ lsp.handlers[Methods.textDocument_rename] = function(params, callback)
 	local new_name = params.newName:gsub("^[+@]", "")
 
 	if not new_name:match("^[^%s]+$") then
-		return callback({ code = 1, message = "Invalid name: must be alphanumeric, no spaces or special characters" }, {})
+		return callback({ code = 1, message = "Invalid name: cannot contain spaces" }, {})
 	end
 
 	local edits = vim

--- a/lua/todotxt/lsp/utils.lua
+++ b/lua/todotxt/lsp/utils.lua
@@ -117,8 +117,8 @@ end
 --- @return string
 function utils.get_description(text)
 	local stripped = text
-		:gsub("%+%w+", "") -- +project
-		:gsub("@%w+", "") -- @context
+		:gsub("%+[^%s]+", "") -- +project
+		:gsub("@[^%s]+", "") -- @context
 		:gsub("[%w-]+:%S+", "") -- key:value
 
 	return stripped:gsub("%s+", " "):match("^%s*(.-)%s*$")

--- a/lua/todotxt/parser/regex.lua
+++ b/lua/todotxt/parser/regex.lua
@@ -6,11 +6,11 @@
 
 local patterns = {
 	completed = "^x%s+",
-	context = "@%w+",
+	context = "@[^%s]+",
 	date = "%d%d%d%d%-%d%d%-%d%d",
 	priority_letter = "%((%a)%)",
 	priority_with_space = "%(%a%)%s+",
-	project = "%+%w+",
+	project = "%+[^%s]+",
 }
 
 local utils = require("todotxt.parser.utils")

--- a/tests/test_lsp.lua
+++ b/tests/test_lsp.lua
@@ -58,6 +58,20 @@ T["completion"]["shows all contexts from buffer"] = function()
 	eq(true, vim.list_contains(labels, "@work"))
 end
 
+T["completion"]["shows dotted projects and contexts"] = function()
+	utils.setup_lsp_test(child, { "+home.kitchen Task one", "@when_grandpa_is_home Task two" })
+	utils.call_lsp_handler(child, "textDocument/completion", {
+		textDocument = { uri = "" },
+		position = { line = 0, character = 0 },
+	})
+
+	local items = child.lua_get("_G.lsp_result.items")
+	local labels = vim.iter(items):map(function(i) return i.label end):totable()
+
+	eq(true, vim.list_contains(labels, "+home.kitchen"))
+	eq(true, vim.list_contains(labels, "@when_grandpa_is_home"))
+end
+
 T["completion"]["shows all key: prefixes from buffer"] = function()
 	utils.setup_lsp_test(child, { "due:2025-01-01 Task one", "effort:2h Task two" })
 	utils.call_lsp_handler(child, "textDocument/completion", {
@@ -236,6 +250,17 @@ T["formatting"]["skips empty lines without errors"] = function()
 	eq("2025-01-01 desc @ctx +proj", edits[1].newText)
 end
 
+T["formatting"]["preserves dotted tags in canonical order"] = function()
+	utils.setup_lsp_test(child, { "+a.b.c @x.y.z Task" })
+	utils.call_lsp_handler(child, "textDocument/formatting", {
+		textDocument = { uri = "" },
+	})
+
+	local edits = child.lua_get("_G.lsp_result")
+	eq(1, #edits)
+	eq("Task @x.y.z +a.b.c", edits[1].newText)
+end
+
 T["code_action"] = test.new_set()
 
 T["code_action"]["returns all expected action commands"] = function()
@@ -362,6 +387,28 @@ T["references"]["returns empty when no tag under cursor"] = function()
 	eq(0, #result)
 end
 
+T["references"]["finds dotted project tag"] = function()
+	utils.setup_lsp_test(child, { "+home.kitchen Task one", "+home.kitchen Task two", "+other Task" })
+	utils.call_lsp_handler(child, "textDocument/references", {
+		textDocument = { uri = "" },
+		position = { line = 0, character = 0 },
+	})
+
+	local result = child.lua_get("_G.lsp_result")
+	eq(2, #result)
+end
+
+T["references"]["finds dotted context tag"] = function()
+	utils.setup_lsp_test(child, { "@when_grandpa_is_home Task one", "@when_grandpa_is_home Task two" })
+	utils.call_lsp_handler(child, "textDocument/references", {
+		textDocument = { uri = "" },
+		position = { line = 0, character = 0 },
+	})
+
+	local result = child.lua_get("_G.lsp_result")
+	eq(2, #result)
+end
+
 -- Prepare rename -------------------------------------------------------------
 
 T["prepare_rename"] = test.new_set()
@@ -463,6 +510,21 @@ T["rename"]["returns nil when no tag under cursor"] = function()
 
 	local result = child.lua_get("_G.lsp_result")
 	eq(vim.NIL, result)
+end
+
+T["rename"]["renames dotted project tag"] = function()
+	utils.setup_lsp_test(child, { "+home.kitchen Task one", "+home.kitchen Task two" })
+	utils.call_lsp_handler(child, "textDocument/rename", {
+		textDocument = { uri = "" },
+		position = { line = 0, character = 0 },
+		newName = "home.renovation",
+	})
+
+	local result = child.lua_get("_G.lsp_result")
+	local changes = vim.tbl_values(result.changes)[1]
+	eq(2, #changes)
+	eq("+home.renovation", changes[1].newText)
+	eq("+home.renovation", changes[2].newText)
 end
 
 T["initialize"] = test.new_set()

--- a/tests/test_parser.lua
+++ b/tests/test_parser.lua
@@ -44,6 +44,20 @@ T["parse_line"]["task with projects and contexts"] = function()
 	eq(result.description, "Task +work +personal @phone @home")
 end
 
+T["parse_line"]["task with dotted projects and contexts"] = function()
+	local result = child.lua("return require('todotxt.parser').parse('(A) Task +home.kitchen @when_grandpa_is_home')")
+	eq(result.is_completed, false)
+	eq(result.priority, "A")
+	eq(result.projects, { "home.kitchen" })
+	eq(result.contexts, { "when_grandpa_is_home" })
+end
+
+T["parse_line"]["dotted tag with multiple sub-levels"] = function()
+	local result = child.lua("return require('todotxt.parser').parse('Task +a.b.c @x.y.z')")
+	eq(result.projects, { "a.b.c" })
+	eq(result.contexts, { "x.y.z" })
+end
+
 T["parse_line"]["task with key-value metadata"] = function()
 	local result = child.lua("return require('todotxt.parser').parse('Task due:2025-12-31 rec:+1w')")
 	eq(result.kv.due, "2025-12-31")

--- a/tests/test_todotxt.lua
+++ b/tests/test_todotxt.lua
@@ -243,6 +243,12 @@ T["sort_tasks_by_priority()"]["sorts tasks by different criteria"] = function()
 		expected = { "(A) Task with +multiple +projects", "(B) Task with +one_project" },
 	}
 	utils.test_sort_function(child, "sort_tasks_by_project", multi_project_test.shuffled, multi_project_test.expected)
+
+	local dotted_project_test = {
+		shuffled = { "(B) Task +a.b", "(A) Task +a" },
+		expected = { "(A) Task +a", "(B) Task +a.b" },
+	}
+	utils.test_sort_function(child, "sort_tasks_by_project", dotted_project_test.shuffled, dotted_project_test.expected)
 end
 
 T["sort_tasks_by_due_date()"] = new_set()


### PR DESCRIPTION
Align regex parser with tree-sitter backend by using `[^%s]+` instead of `%w+` for project and context tags, allowing dotted sub-tags like `+home.kitchen` and `@when_grandpa_is_home`.

Tree-sitter parser already supported this natively via `/[^\s]+/` in its grammar.