### PR TITLE
fix(lsp): use the correct call for todotxt.move_done

### DIFF
--- a/lua/todotxt/init.lua
+++ b/lua/todotxt/init.lua
@@ -166,6 +166,9 @@ todotxt.move_done_tasks = function()
 	)
 end
 
+--- Keeping the move_done if somebody is already using it.
+todotxt.move_done = todotxt.move_done_tasks
+
 --- Toggles ghost text display
 --- @return nil
 todotxt.toggle_ghost_text = function() require("todotxt.ghost_text").toggle() end

--- a/lua/todotxt/lsp/init.lua
+++ b/lua/todotxt/lsp/init.lua
@@ -203,7 +203,7 @@ lsp.handlers[Methods.workspace_executeCommand] = function(params, callback)
 		["todotxt.sort.project"] = todotxt.sort_tasks_by_project,
 		["todotxt.sort.context"] = todotxt.sort_tasks_by_context,
 		["todotxt.sort.due_date"] = todotxt.sort_tasks_by_due_date,
-		["todotxt.move_done"] = todotxt.move_done,
+		["todotxt.move_done"] = todotxt.move_done_tasks,
 	}
 
 	local fn = fns[params.command]

--- a/tests/test_lsp.lua
+++ b/tests/test_lsp.lua
@@ -280,6 +280,7 @@ T["code_action"]["returns all expected action commands"] = function()
 	eq(true, vim.list_contains(titles, "Sort by project"))
 	eq(true, vim.list_contains(titles, "Sort by context"))
 	eq(true, vim.list_contains(titles, "Sort by due date"))
+	eq(true, vim.list_contains(titles, "Move done tasks"))
 end
 
 T["execute_command"] = test.new_set()
@@ -304,6 +305,19 @@ T["execute_command"]["cycle priority advances to next letter"] = function()
 
 	local lines = utils.get_buffer_content(child)
 	eq("(B) 2025-01-01 Test task", lines[1])
+end
+
+T["execute_command"]["move done moves completed tasks"] = function()
+	utils.setup_lsp_test(child, { "x 2025-01-01 Completed task", "Pending task" })
+	utils.call_lsp_handler(child, "workspace/executeCommand", {
+		command = "todotxt.move_done",
+		arguments = {},
+	})
+
+	eq(vim.NIL, child.lua_get("_G.lsp_err"))
+	local lines = utils.get_buffer_content(child)
+	eq({ "Pending task" }, lines)
+	eq({ "x 2025-01-01 Completed task" }, child.lua_get("vim.fn.readfile(M.config.donetxt)"))
 end
 
 T["code_action"]["includes metadata sort commands when configured"] = function()


### PR DESCRIPTION
The `todotxt.move_done` LSP action was calling a nonexistent `todotxt.move_done` function, I changed it to call `todotxt.move_done_tasks` instead. And also:

- Added a quick test for it.
- Added an alias as `todotxt.move_done` In case someone is already using the todotxt.move_done function in their config somehow.